### PR TITLE
Scala snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,36 @@ Get the latest Sublime Text 2 beta from http://www.sublimetext.com/2.
 
 ### Code snippets
 
-- `action ➝` : Creates an action
-- `controller ➝` : Creates a Controller structure
-- `global ➝` : Creates a Global object structure
+- `action ➝` : Creates an action (scala & java)
+- `actor ➝` : Get an actor from Akka (scala & java)
+- `aync ➝` : Creates an async result (scala & java)
+- `bindform ➝` : Creates form binding from request structure (scala & java)
+- `cacheget ➝` : Retrieve value from cache (scala & java)
+- `cacheset ➝` : Put value in cache (scala & java)
+- `callbackenum ➝` : Creates callback enumerator (scala)
+- `controller ➝` : Creates a Controller structure (scala & java)
+- `dbconn ➝` : Creates a DB.withConnection structure (scala & java)
+- `dbtrans ➝` : Creates a DB..withTransaction structure (scala & java)
+- `entity ➝` : Creates a Ebean entity structure (java)
 - `evolutions ➝` : Creates the evolution up/down tags in sql file
+- `pforeach ➝` : Creates an foreach structure in templates (html)
+- `form ➝` : Creates a simple form structure (scala & java)
+- `pform ➝` : Creates a simple html form (html)
+- `fromconf ➝` : Creates value from conf file (scala & java)
+- `global ➝` : Creates a Global object structure (scala & java)
+- `htmlform ➝` : Creates a form in templates (html)
+- `model ➝` : Creates a JDBC model structure (scala)
+- `ok ➝` : Creates a Ok result (scala & java)
+- `pushenum ➝` : Creates an imperative enumerator (scala)
+- `redirect ➝` : Creates redirection (scala & java)
+- `schedule ➝` : Creates a scheduled task (scala & java)
+- `sql ➝` : Creates a SQL structure (scala)
+- `sessionget ➝` : Retrieve a value from session (scala & java)
+- `sessionset ➝` : Put value in session (scala & java)
+- `sse ➝` : Creates a SSE action (scala)
+- `tupleform ➝` : Creates a multiple input form (scala)
+- `template ➝` : Creates a html template structure (html)
+- `websocket ➝` : Creates a websocket action (scala & java)
 
 ## Theme
 

--- a/actor.sublime-snippet
+++ b/actor.sublime-snippet
@@ -1,0 +1,7 @@
+<snippet>
+	<content><![CDATA[
+val ${1:actor} = Akka.system.actorOf(Props[${2:MyActor}], name = "${1:actor}")
+]]></content>
+	<tabTrigger>actor</tabTrigger>
+	<scope>source.scala</scope>
+</snippet>

--- a/async.sublime-snippet
+++ b/async.sublime-snippet
@@ -1,0 +1,14 @@
+<snippet>
+    <content><![CDATA[
+val ${1:promise} = Akka.future { ${2:/** blocking stuff **/} }
+Async {
+    ${1:promise}.map { ${3:result} => Ok( views.html.${4:index}(${3:result}) ) }
+}
+]]></content>
+    <tabTrigger>async</tabTrigger>
+    <scope>source.scala</scope>
+</snippet>
+
+
+
+

--- a/bindform.sublime-snippet
+++ b/bindform.sublime-snippet
@@ -1,0 +1,12 @@
+<snippet>
+	<content><![CDATA[
+${1:form}.bindFromRequest.fold (
+    formWithErrors => BadRequest( ${2:"You need to pass a 'xxx' value!"} ),
+    { maybeValue =>
+        ${3:Ok}
+    }
+)		
+]]></content>
+	<tabTrigger>bindform</tabTrigger>
+	<scope>source.scala</scope>
+</snippet>

--- a/cacheget.sublime-snippet
+++ b/cacheget.sublime-snippet
@@ -1,0 +1,7 @@
+<snippet>
+	<content><![CDATA[
+val maybe: Option[${1:String}] = Cache.getAs[${1:String}]("${2:item.key}")
+]]></content>
+	<tabTrigger>cacheget</tabTrigger>
+	<scope>source.scala</scope>
+</snippet>

--- a/cacheset.sublime-snippet
+++ b/cacheset.sublime-snippet
@@ -1,0 +1,7 @@
+<snippet>
+	<content><![CDATA[
+Cache.set("${1:item.key}", $2)
+]]></content>
+	<tabTrigger>cacheset</tabTrigger>
+	<scope>source.scala</scope>
+</snippet>

--- a/callbackenum.sublime-snippet
+++ b/callbackenum.sublime-snippet
@@ -1,0 +1,9 @@
+<snippet>
+	<content><![CDATA[
+val ${1:enumerator} = Enumerator.fromCallback{ () =>
+    Promise.timeout( Some( ${2:"stuff"} ), ${3:1000}, TimeUnit.${4:MILLISECONDS} )
+} 
+]]></content>
+	<tabTrigger>callbackenum</tabTrigger>
+	<scope>source.scala</scope>
+</snippet>

--- a/controller.sublime-snippet
+++ b/controller.sublime-snippet
@@ -4,6 +4,20 @@ package controllers
 
 import play.api._
 import play.api.mvc._
+import play.api.data.Forms._
+import play.api.data._
+/** Uncomment the following lines as needed **/
+/**
+import play.api.Play.current
+import play.api.libs._
+import play.api.libs.iteratee._
+import play.api.libs.concurrent._
+import java.util.concurrent._
+import scala.concurrent.stm._
+import akka.util.duration._
+import play.api.cache._
+import play.api.libs.json._
+**/
 
 object ${1:Application} extends Controller {
 

--- a/dbconn.sublime-snippet
+++ b/dbconn.sublime-snippet
@@ -1,0 +1,9 @@
+<snippet>
+	<content><![CDATA[
+DB.withConnection { implicit conn =>
+    $1
+}
+]]></content>
+	<tabTrigger>dbconn</tabTrigger>
+	<scope>source.scala</scope>
+</snippet>

--- a/dctrans.sublime-snippet
+++ b/dctrans.sublime-snippet
@@ -1,0 +1,9 @@
+<snippet>
+	<content><![CDATA[
+DB.withTransaction { implicit conn =>
+    $1
+}
+]]></content>
+	<tabTrigger>dbtrans</tabTrigger>
+	<scope>source.scala</scope>
+</snippet>

--- a/form.sublime-snippet
+++ b/form.sublime-snippet
@@ -1,0 +1,7 @@
+<snippet>
+	<content><![CDATA[
+val ${1:form} = Form( "${2:param1}" -> ${3:text} )
+]]></content>
+	<tabTrigger>form</tabTrigger>
+	<scope>source.scala</scope>
+</snippet>

--- a/fromconf.sublime-snippet
+++ b/fromconf.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+	<content><![CDATA[
+val base = ${1:current}.configuration.getString( ${2:"stuff"} )
+    .getOrElse( ${3:"orstuff"} )
+]]></content>
+	<tabTrigger>fromconf</tabTrigger>
+	<scope>source.scala</scope>
+</snippet>

--- a/ok.sublime-snippet
+++ b/ok.sublime-snippet
@@ -1,0 +1,7 @@
+<snippet>
+    <content><![CDATA[
+Ok( views.html.${1:index}($2) )
+]]></content>
+    <tabTrigger>ok</tabTrigger>
+    <scope>source.scala</scope>
+</snippet>

--- a/pushenum.sublime-snippet
+++ b/pushenum.sublime-snippet
@@ -1,0 +1,16 @@
+<snippet>
+	<content><![CDATA[
+val ${1:hubEnumerator} = Enumerator.imperative[${2:String}]()
+
+val hub = Concurrent.hub[${2:String}]( hubEnumerator )
+  
+def push( ${3:msg}: ${2:String} ) = {
+    hubEnumerator.push( msg )
+}
+// consume with hub.getPatchCord()
+]]></content>
+	<tabTrigger>pushenum</tabTrigger>
+	<scope>source.scala</scope>
+</snippet>
+
+

--- a/redirect.sublime-snippet
+++ b/redirect.sublime-snippet
@@ -1,0 +1,7 @@
+<snippet>
+	<content><![CDATA[
+Redirect( routes.Application.${1:index()} )
+]]></content>
+	<tabTrigger>redirect</tabTrigger>
+	<scope>source.scala</scope>
+</snippet>

--- a/schedule.sublime-snippet
+++ b/schedule.sublime-snippet
@@ -1,0 +1,11 @@
+<snippet>
+    <content><![CDATA[
+Akka.system.scheduler.schedule( 0 millisecond, ${1:10} ${2:seconds} ) {
+    $3
+}
+]]></content>
+    <tabTrigger>schedule</tabTrigger>
+    <scope>source.scala</scope>
+</snippet>
+
+

--- a/sessionget.sublime-snippet
+++ b/sessionget.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+    <content><![CDATA[
+request.session.get("${1:key}")${2://}.map { $3 }.getOrElse { $4 } 
+]]></content>
+    <tabTrigger>sessionget</tabTrigger>
+    <scope>source.scala</scope>
+</snippet>
+

--- a/sessionset.sublime-snippet
+++ b/sessionset.sublime-snippet
@@ -1,0 +1,11 @@
+<snippet>
+    <content><![CDATA[
+Ok( views.html.${1:index}($2) ).withSession(
+  session + ("${3:key}" -> "${4:value}")
+)
+]]></content>
+    <tabTrigger>sessionset</tabTrigger>
+    <scope>source.scala</scope>
+</snippet>
+
+

--- a/sql.sublime-snippet
+++ b/sql.sublime-snippet
@@ -1,0 +1,7 @@
+<snippet>
+	<content><![CDATA[
+SQL( "$1" )${2://}.on( )${3://}.as( )
+]]></content>
+	<tabTrigger>sql</tabTrigger>
+	<scope>source.scala</scope>
+</snippet>

--- a/sse.sublime-snippet
+++ b/sse.sublime-snippet
@@ -1,0 +1,19 @@
+<snippet>
+	<content><![CDATA[
+def ${1:sse}() = Action { implicit request =>
+    SimpleResult(
+        header = ResponseHeader(
+            OK, 
+            Map(
+                CONTENT_LENGTH -> "-1",
+                CONTENT_TYPE -> "text/event-stream"
+                )
+            ), 
+            ${2:hub}.getPatchCord().through( Enumeratee.map[${3:String}] { msg => "data: " + msg + "\n\n" } 
+        )
+    )
+}
+]]></content>
+	<tabTrigger>sse</tabTrigger>
+	<scope>source.scala</scope>
+</snippet>

--- a/tupleform.sublime-snippet
+++ b/tupleform.sublime-snippet
@@ -1,0 +1,7 @@
+<snippet>
+	<content><![CDATA[
+val ${1:form} = Form( tuple( "${2:param1}" -> ${3:text}, "${4:param2}" -> ${5:text} ) )
+]]></content>
+	<tabTrigger>tupleform</tabTrigger>
+	<scope>source.scala</scope>
+</snippet>

--- a/websocket.sublime-snippet
+++ b/websocket.sublime-snippet
@@ -1,0 +1,15 @@
+<snippet>
+	<content><![CDATA[
+def ${1:websocket}() = WebSocket.async[${2:String}] { request =>
+    var out = ${3:hub}.getPatchCord( )
+    var in = Iteratee.foreach[${2:String}] ( _ match {
+        case message : ${2:String} => {
+            hubEnumerator.push( message )
+        }
+    })
+    Promise.pure( ( in, out ) )
+}
+]]></content>
+	<tabTrigger>websocket</tabTrigger>
+	<scope>source.scala</scope>
+</snippet>


### PR DESCRIPTION
New snippets for the Play 2.0 Scala API. With these snippets you can use :
- `action ➝` : Creates an action (scala & java)
- `actor ➝` : Get an actor from Akka (scala & java)
- `aync ➝` : Creates an async result (scala & java)
- `bindform ➝` : Creates form binding from request structure (scala & java)
- `cacheget ➝` : Retrieve value from cache (scala & java)
- `cacheset ➝` : Put value in cache (scala & java)
- `callbackenum ➝` : Creates callback enumerator (scala)
- `controller ➝` : Creates a Controller structure (scala & java)
- `dbconn ➝` : Creates a DB.withConnection structure (scala & java)
- `dbtrans ➝` : Creates a DB..withTransaction structure (scala & java)
- `form ➝` : Creates a simple form structure (scala & java)
- `fromconf ➝` : Creates value from conf file (scala & java)
- `global ➝` : Creates a Global object structure (scala & java)
- `model ➝` : Creates a JDBC model structure (scala)
- `ok ➝` : Creates a Ok result (scala & java)
- `pushenum ➝` : Creates an imperative enumerator (scala)
- `redirect ➝` : Creates redirection (scala & java)
- `schedule ➝` : Creates a scheduled task (scala & java)
- `sql ➝` : Creates a SQL structure (scala)
- `sessionget ➝` : Retrieve a value from session (scala & java)
- `sessionset ➝` : Put value in session (scala & java)
- `sse ➝` : Creates a SSE action (scala)
- `tupleform ➝` : Creates a multiple input form (scala)
- `websocket ➝` : Creates a websocket action (scala & java)
