### PR TITLE
Temporary fix for crash of Sublime Text 2 Build 2181.

### DIFF
--- a/templates.tmLanguage
+++ b/templates.tmLanguage
@@ -1509,10 +1509,12 @@
 					<key>include</key>
 					<string>#scala-block</string>
 				</dict>
+				<!-- circular dependency? see line 220.
 				<dict>
 					<key>include</key>
 					<string>#call-block-continuation</string>
 				</dict>
+				-->
 				<dict>
 					<key>include</key>
 					<string>#call-continuation</string>


### PR DESCRIPTION
I discovered this problem while attempting to view _/samples/computer-database/app/views/list.scala.html_ from the Play 2.0 package.

The `}.getOrElse {` call block continuation is the culprit. My Sublime Text build becomes unresponsive with such code present in any scala.html file.

I think the cause is a circular dependency between #call-block-continuation and #template-content, but I am very new to working with .tmLanguage files.
